### PR TITLE
Add tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = "1.0"
 quote = "1.0"
+
+[dependencies.syn]
+version = "1.0"
+features = ["full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ quote = "1.0"
 [dependencies.syn]
 version = "1.0"
 features = ["full"]
+
+[dev-dependencies]
+static_assertions = "1"
+vtables = { path = "../vtables" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,3 +145,6 @@ pub fn virtual_index(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     gen.into()
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,3 @@ pub fn virtual_index(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     gen.into()
 }
-
-#[cfg(test)]
-mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,0 @@
-use super::*;
-
-#[test]
-fn pass() {
-    assert!(true);
-}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+#[test]
+fn pass() {
+    assert!(true);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,6 @@
+#![allow(dead_code)]
+
+use core::ptr;
 use static_assertions as sa;
 use std::os::raw::*;
 use vtables::VTable;
@@ -5,7 +8,16 @@ use vtables_derive::{has_vtable, virtual_index, VTable};
 
 #[has_vtable]
 #[derive(VTable, Debug)]
-pub struct EngineClient {
+struct EngineClient {
+}
+
+// This structure will fail to compile if #[has_vtable] added another `vtable` field.
+#[has_vtable]
+struct AlreadyHasVTableField<'a> {
+    vtable: u8, 
+    foo: bool,
+    bar: f32,
+    baz: Option<&'a u8>,
 }
 
 #[allow(non_snake_case)]
@@ -24,6 +36,46 @@ impl EngineClient {
 }
 
 #[test]
-fn pass() {
-    assert!(true);
+fn has_vtable_adds_vtable_field() {
+    // This function will fail to compile if #[has_vtable] does not add a `vtable`.
+    
+    sa::assert_fields!(EngineClient: vtable);
+}
+
+#[test]
+fn derive_vtable_adds_get_virtual_method() {
+    // This function will fail to compile if #[derive(VTable)] did not add a `get_virtual(usize)` method.
+    
+    let engine_client = EngineClient {
+        vtable: ptr::null_mut(),
+    };
+
+    let _f = |i| {
+        type ExampleVirtualMethod = fn(&EngineClient, bool) -> f64;
+        unsafe { engine_client.get_virtual::<ExampleVirtualMethod>(i) };
+    };
+}
+
+#[test]
+fn virtual_index_retains_declared_methods() {
+    // This function will fail to compile if #[virtual_index(...)] fails to emit the method it decorates.
+    
+    let engine_client = EngineClient {
+        vtable: ptr::null_mut(),
+    };
+
+    macro_rules! verify {
+        ($method:ident) => {{
+            verify!($method,)
+        }};
+
+        ($method:ident, $($arg:ident),*) => {{
+            let _f = |$($arg),*| engine_client.$method($($arg),*);
+        }};
+    }
+
+    verify!(GetScreenSize, w, h);
+    verify!(IsInGame);
+    verify!(ExecuteClientCmd, command);
+    verify!(ClientCmd_Unrestricted, command);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,29 @@
+use static_assertions as sa;
+use std::os::raw::*;
+use vtables::VTable;
+use vtables_derive::{has_vtable, virtual_index, VTable};
+
+#[has_vtable]
+#[derive(VTable, Debug)]
+pub struct EngineClient {
+}
+
+#[allow(non_snake_case)]
+impl EngineClient {
+    #[virtual_index(5)]
+    pub fn GetScreenSize(&self, width: *mut i32, height: *mut i32) {}
+    
+    #[virtual_index(26)]
+    pub fn IsInGame(&self) -> bool {}
+
+    #[virtual_index(108)]
+    pub fn ExecuteClientCmd(&self, command: *const c_char) {}
+
+    #[virtual_index(113)]
+    pub fn ClientCmd_Unrestricted(&self, command: *const c_char) {}
+}
+
+#[test]
+fn pass() {
+    assert!(true);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::pedantic)]
 #![allow(dead_code)]
 
 use core::ptr;
@@ -9,6 +10,7 @@ use vtables_derive::{has_vtable, virtual_index, VTable};
 #[has_vtable]
 #[derive(VTable, Debug)]
 struct EngineClient {
+    test_field: u64,
 }
 
 // This structure will fail to compile if #[has_vtable] added another `vtable` field.
@@ -20,8 +22,23 @@ struct AlreadyHasVTableField<'a> {
     baz: Option<&'a u8>,
 }
 
+impl Default for EngineClient {
+    fn default() -> Self {
+        Self {
+            vtable: ptr::null_mut(),
+            test_field: 0,
+        }
+    }
+}
+
 #[allow(non_snake_case)]
 impl EngineClient {
+    #[virtual_index(0)]
+    pub fn GetTestField(&self) -> u64 {}
+
+    #[virtual_index(1)]
+    pub fn MutateTestField(&mut self, new_value: u64) {}
+
     #[virtual_index(5)]
     pub fn GetScreenSize(&self, width: *mut i32, height: *mut i32) {}
     
@@ -33,12 +50,12 @@ impl EngineClient {
 
     #[virtual_index(113)]
     pub fn ClientCmd_Unrestricted(&self, command: *const c_char) {}
+
 }
 
 #[test]
 fn has_vtable_adds_vtable_field() {
     // This function will fail to compile if #[has_vtable] does not add a `vtable`.
-    
     sa::assert_fields!(EngineClient: vtable);
 }
 
@@ -46,9 +63,7 @@ fn has_vtable_adds_vtable_field() {
 fn derive_vtable_adds_get_virtual_method() {
     // This function will fail to compile if #[derive(VTable)] did not add a `get_virtual(usize)` method.
     
-    let engine_client = EngineClient {
-        vtable: ptr::null_mut(),
-    };
+    let engine_client = EngineClient::default();
 
     let _f = |i| {
         type ExampleVirtualMethod = fn(&EngineClient, bool) -> f64;
@@ -60,9 +75,7 @@ fn derive_vtable_adds_get_virtual_method() {
 fn virtual_index_retains_declared_methods() {
     // This function will fail to compile if #[virtual_index(...)] fails to emit the method it decorates.
     
-    let engine_client = EngineClient {
-        vtable: ptr::null_mut(),
-    };
+    let engine_client = EngineClient::default();
 
     macro_rules! verify {
         ($method:ident) => {{
@@ -80,9 +93,18 @@ fn virtual_index_retains_declared_methods() {
     verify!(ClientCmd_Unrestricted, command);
 }
 
+fn new_vtable_with_one_function(function_index: usize, function_pointer: *mut usize) -> Vec<*mut usize> {
+    // [null, null, null, ..., function_pointer, null, ...]
+    //   0     1     2          function_index   NUM_NULL_ENTRIES_AFTER_FUNCTION
+    const NUM_NULL_ENTRIES_AFTER_FUNCTION: usize = 3;
+    let num_total_entries = 1 + function_index + NUM_NULL_ENTRIES_AFTER_FUNCTION;
+    let mut vtable = vec![ptr::null_mut(); num_total_entries];
+    vtable[function_index] = function_pointer;
+    vtable
+}
+
 #[test]
-fn calling_void_virtual_method_works() {
-    use ptr::null_mut as null;
+fn call_void_virtual_method() {
     const WIDTH_ASSERT: i32 = 800;
     const HEIGHT_ASSERT: i32 = 600;
 
@@ -91,22 +113,11 @@ fn calling_void_virtual_method_works() {
         *height = HEIGHT_ASSERT;
     }
 
-    let function_ptr = get_screen_size_impl as *mut usize;
-
-    let mut vtable = [
-        null(),         // 0
-        null(),         // 1
-        null(),         // 2
-        null(),         // 3
-        null(),         // 4
-        function_ptr,   // 5
-        null(),
-        null(),
-        // and so on.
-    ];
+    let mut vtable = new_vtable_with_one_function(5, get_screen_size_impl as _);
 
     let engine_client = EngineClient {
         vtable: vtable.as_mut_ptr(),
+        ..Default::default()
     };
 
     let mut width = 0;
@@ -115,4 +126,22 @@ fn calling_void_virtual_method_works() {
  
     assert_eq!(width, WIDTH_ASSERT);
     assert_eq!(height, HEIGHT_ASSERT);
+}
+
+#[test]
+fn call_virtual_method_to_return_internal_field() {
+    const FIELD_ASSERT: u64 = 0xCafeBabe;
+
+    fn get_test_field_impl(client: &EngineClient) -> u64 {
+        client.test_field
+    }
+
+    let mut vtable = new_vtable_with_one_function(0, get_test_field_impl as _);
+
+    let engine_client = EngineClient {
+        vtable: vtable.as_mut_ptr(),
+        test_field: FIELD_ASSERT
+    };
+
+    assert_eq!(engine_client.GetTestField(), FIELD_ASSERT);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -79,3 +79,40 @@ fn virtual_index_retains_declared_methods() {
     verify!(ExecuteClientCmd, command);
     verify!(ClientCmd_Unrestricted, command);
 }
+
+#[test]
+fn calling_void_virtual_method_works() {
+    use ptr::null_mut as null;
+    const WIDTH_ASSERT: i32 = 800;
+    const HEIGHT_ASSERT: i32 = 600;
+
+    unsafe fn get_screen_size_impl(_client: &EngineClient, width: *mut i32, height: *mut i32) {
+        *width = WIDTH_ASSERT;
+        *height = HEIGHT_ASSERT;
+    }
+
+    let function_ptr = get_screen_size_impl as *mut usize;
+
+    let mut vtable = [
+        null(),         // 0
+        null(),         // 1
+        null(),         // 2
+        null(),         // 3
+        null(),         // 4
+        function_ptr,   // 5
+        null(),
+        null(),
+        // and so on.
+    ];
+
+    let engine_client = EngineClient {
+        vtable: vtable.as_mut_ptr(),
+    };
+
+    let mut width = 0;
+    let mut height = 0;
+    engine_client.GetScreenSize(&mut width, &mut height);
+ 
+    assert_eq!(width, WIDTH_ASSERT);
+    assert_eq!(height, HEIGHT_ASSERT);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -145,3 +145,25 @@ fn call_virtual_method_to_return_internal_field() {
 
     assert_eq!(engine_client.GetTestField(), FIELD_ASSERT);
 }
+
+#[test]
+fn call_virtual_method_to_mutate_internal_field() {
+    const FIELD_ASSERT: u64 = 0xDeadBeef;
+
+    fn mutate_test_field_impl(client: &mut EngineClient, new_value: u64) {
+        client.test_field = new_value;
+    }
+
+    let mut vtable = new_vtable_with_one_function(1, mutate_test_field_impl as _);
+
+    let mut engine_client = EngineClient {
+        vtable: vtable.as_mut_ptr(),
+        test_field: 0,
+    };
+
+    assert_eq!(engine_client.test_field, 0);
+
+    engine_client.MutateTestField(FIELD_ASSERT);
+
+    assert_eq!(engine_client.test_field, FIELD_ASSERT);
+}


### PR DESCRIPTION
Most of the tests are compile-time, e.g., emitting a helpful compiler error when a `#[has_vtable]` struct does not contain a `vtable` field.

The other tests set up a basic virtual table for the `EngineClient` and asserts whether one can make calls to the methods decorated with `#[virtual_index(...)]`.

Run tests by executing `cargo test` in the crate working directory.

Looking through the macro implementation, I've been keeping a list of possible improvements. I'll write those in a separate issue or PR.