### PR TITLE
Refactor #[has_vtable], Generics support, and non-clobbering #[repr(C)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ use syn::{
     DeriveInput, ExprLit, FnArg, ItemFn, ItemStruct, Lit, Pat, Result, Type,
 };
 
-fn impl_vtable(ast: &syn::DeriveInput) -> TokenStream {
-    let name = &ast.ident;
+fn impl_vtable(ast: syn::DeriveInput) -> TokenStream {
+    let name = ast.ident;
     let gen = quote! {
         impl VTable for #name {
             unsafe fn get_virtual<T: Sized>(&self, index: usize) -> T {
@@ -27,6 +27,7 @@ fn impl_vtable(ast: &syn::DeriveInput) -> TokenStream {
 #[proc_macro_derive(VTable)]
 pub fn vtable_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
+    impl_vtable(ast)
 }
 
 #[proc_macro_attribute]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::pedantic)]
 extern crate proc_macro;
 
 use crate::proc_macro::TokenStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,18 +46,22 @@ fn add_vtable_field(item_struct: &mut ItemStruct) {
         panic!("You can only decorate with #[has_vtable] a struct that has named fields.");
     };
 
-    let vtable_field = Field::parse_named
-        .parse2(quote! { pub vtable: *mut *mut usize })
-        .expect("internal macro error with ill-formatted vtable field");
-    
     let struct_already_has_vtable_field = fields
-        .named
-        .iter()
-        .any(|f| f.ident == vtable_field.ident);
-
+    .named
+    .iter()
+    .any(|f| f
+        .ident
+        .as_ref()
+        .map_or(false, |i| i == "vtable")
+    );
+    
     if struct_already_has_vtable_field {
         return;
     }
+    
+    let vtable_field = Field::parse_named
+        .parse2(quote! { pub vtable: *mut *mut usize })
+        .expect("internal macro error with ill-formatted vtable field");
 
     fields
         .named

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,8 @@ use syn::{
     self,
     parse::{Parse, Parser, ParseStream},
     parse_macro_input,
-    parse_quote,
     spanned::Spanned,
-    Attribute, AttrStyle, DeriveInput, ExprLit, Field, FnArg, ItemFn, ItemStruct, Lit, Meta, MetaList, NestedMeta, Pat, Path, Result, Type,
+    Attribute, DeriveInput, ExprLit, Field, FnArg, ItemFn, ItemStruct, Lit, Meta, MetaList, NestedMeta, Pat, Result, Type,
     Fields::Named,
 };
 
@@ -73,8 +72,7 @@ fn has_repr_c(item_struct: &ItemStruct) -> bool {
     let has = |meta: &Meta, ident| meta
         .path()
         .get_ident()
-        .map(|i| i.to_string() == ident)
-        .unwrap_or(false);
+        .map_or(false, |i| i == ident);
 
     item_struct
         .attrs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@ fn impl_vtable(ast: &syn::DeriveInput) -> TokenStream {
 
 #[proc_macro_derive(VTable)]
 pub fn vtable_derive(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = syn::parse(input).unwrap();
-    impl_vtable(&ast)
+    let ast = parse_macro_input!(input as DeriveInput);
 }
 
 #[proc_macro_attribute]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -226,3 +226,156 @@ fn call_virtual_method_to_mutate_internal_field() {
 
     assert_eq!(engine_client.test_field, FIELD_ASSERT);
 }
+
+#[test]
+fn check_that_derive_vtable_adds_repr_c() {
+    // To be honest, this test is flaky because it relies on struct layouts
+    // whose stability I'm not familiar with across platforms, rustc versions, etc.
+    // Ideally, there'd be a simpler way to just check if a struct is literally
+    // decorated with the #[repr(C)] attribute rather than going through this dance of looking for
+    // the effects of the attribute.
+
+    // Anyway, here's the theory:
+    // If #[has_vtable] didn't add #[repr(C)] to the struct,
+    // then we'd expect to see the Rust compiler laying out the fields according to #[repr(rust)].
+    // This default layout should order the fields of the struct in decreasing alignment to minimize padding.
+    // With that knowledge, we can probe the struct using raw pointers to look for the unique values we initialize
+    // each field with.
+    // https://github.com/rust-lang/rust/pull/37429
+
+    macro_rules! z { 
+        ($t:ty) => {{ 
+            core::mem::size_of::<$t>() 
+        }} 
+    }
+
+    {
+        // First, test the theory on an undecorated struct.
+        struct Control {
+            least_aligned: u8,
+            somewhat_aligned: u16,
+            most_aligned: u32,
+        }
+        
+        let control = Control {
+            least_aligned: 42,
+            somewhat_aligned: 2019,
+            most_aligned: 0xCafeBabe,
+        };
+
+        /*
+            We expect the Rust compiler to layout `control` in memory as:
+
+            +0: 0xCafeBabe
+            +4: 2019
+            +6: 42
+            +7: 1 byte padding to satisfy alignment constraint of the entire struct.
+
+            i.e., decreasing alignment
+        */
+
+        unsafe {
+            // Verify the fields are in fact laid out in decreasing alignment.
+            let cursor = &control as *const _ as *const u8;
+            let mut offset = 0;
+
+            {
+                let cursor: *const u32 = cursor.add(offset).cast();
+                assert_eq!(*cursor, control.most_aligned);
+                offset += z!(u32);
+            }
+
+            {
+                let cursor: *const u16 = cursor.add(offset).cast();
+                assert_eq!(*cursor, control.somewhat_aligned);
+                offset += z!(u16);
+            }
+            
+            {
+                let cursor: *const u8 = cursor.add(offset).cast();
+                assert_eq!(*cursor, control.least_aligned);
+                offset += z!(u8);
+            }
+
+            // 1 byte padding to align entire struct to a multiple of maximum alignment.
+            offset += 1;
+
+            assert_eq!(z!(Control), offset);
+        }
+    }
+
+    // Great, those tests passed. So the theory is okay to work with.
+    // Now let's decorate a struct with #[has_vtable] to see if it has the #[repr(C)] attribute.
+    // We shouldn't see any of the struct fields moving from their declaration order.
+
+    #[has_vtable]
+    #[derive(VTable)]
+    struct Control {
+        vtable: usize,
+
+        least_aligned: u8,
+        somewhat_aligned: u16,
+        most_aligned: u32,
+    }
+
+    let control = Control {
+        vtable: 0,
+
+        least_aligned: 42,
+        somewhat_aligned: 2019,
+        most_aligned: 0xCafeBabe,
+    };
+
+    /*
+        We expect #[repr(C)] to layout `control` in memory as:
+
+        +0:     0
+
+        +8:     42
+        +9:     1 byte padding to satisfy alignment requirement of 2 bytes for `somewhat_aligned`
+        +10:    2019
+        +12:    0xCafeBabe
+
+        i.e., declaration order with padding to satisfy alignment requirements
+    */
+
+    unsafe {
+        // Verify the fields are in declaration order.
+        let cursor = &control as *const _ as *const u8;
+        let mut offset = z!(usize); // skip past vtable usize
+
+        {
+            let cursor: *const u8 = cursor.add(offset).cast();
+            assert_eq!(*cursor, control.least_aligned);
+            offset += z!(u8);
+        }
+
+        {
+            offset += 1; // 1 byte padding
+            let cursor: *const u16 = cursor.add(offset).cast();
+            assert_eq!(*cursor, control.somewhat_aligned);
+            offset += z!(u16);
+        }
+        
+        {
+            let cursor: *const u32 = cursor.add(offset).cast();
+            assert_eq!(*cursor, control.most_aligned);
+            offset += z!(u32);
+        }
+        
+        assert_eq!(z!(Control), offset);
+    }
+
+    // Sanity check on alignment ordering.
+    
+    macro_rules! a { 
+        ($t:ty) => {{ 
+            core::mem::align_of::<$t>() 
+        }} 
+    }
+
+    let alignments = [a!(u8), a!(u16), a!(u32)];
+
+    assert_eq!(*alignments.iter().min().unwrap(), a!(u8), "u8 should have the smallest alignment constraint.");
+    assert_eq!(*alignments.iter().max().unwrap(), a!(u32), "u32 should have the largest alignment constraint.");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -109,7 +109,6 @@ impl EngineClient {
 
     #[virtual_index(113)]
     pub fn ClientCmd_Unrestricted(&self, command: *const c_char) {}
-
 }
 
 #[test]


### PR DESCRIPTION
1. `#[has_vtable]` will preserve existing `#[repr(C)]` decorations on structs. This preservation is important when you annotate a struct with additional constraints e.g., `#[repr(C, packed(4)]` to specify a custom packing constraint.

2. Both `#[has_vtable]` and `#[derive(VTable)]` will compile for structs with generics and constraints specified either inline, e.g., `T: Clone`, or using a `where` clause, e.g., `where T: Clone`.